### PR TITLE
Add Events Functionality

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+server/.env.production
+server/.env.development
 server/.env
 server/node_modules
 server/dist

--- a/client/src/api/events.api.ts
+++ b/client/src/api/events.api.ts
@@ -1,8 +1,10 @@
 import axios from "axios";
 import {
+  iEvent,
   iGetEvent,
   iGetEvents,
   iGetEventsJoinTeamJoinOrg,
+  iCreateEventInATeam
 } from "../interfaces/events.interface";
 
 // GET EVENTS IN A ORG
@@ -20,7 +22,23 @@ export const getEvents = async function (orgId: number): Promise<iGetEvents> {
   return response.data;
 };
 
-// CREATE AN EVENT IN A ORG
+// Create an event within a team
+export const createEventInATeam = async function (
+  data: Omit<iEvent, "created_by_user_id" | "event_id" | "organization_name" | "team_name" | "created_at" | "updated_at">,
+): Promise<iCreateEventInATeam> {
+  const token = localStorage.getItem("token");
+  if (!token) throw new Error("no token, please log in");
+  const response = await axios.post<iCreateEventInATeam>(
+    `${import.meta.env.VITE_BASE_URL}/organizations/${data.organization_id}/teams/${data.team_id}/events`,
+    data,
+    {
+      headers: {
+        Authorization: `Bearer ${token}`,
+      },
+    }
+  );
+  return response.data;
+}
 
 // GET A SINGLE EVENT IN A ORG
 export const getEventInAnOrg = async function (
@@ -81,6 +99,7 @@ export const getEventsInATeam = async function (
   );
   return response.data;
 };
+
 export const getEventsInAnOrganization = async function (
   orgId: number
 ): Promise<iGetEventsJoinTeamJoinOrg> {
@@ -88,12 +107,13 @@ export const getEventsInAnOrganization = async function (
     `${import.meta.env.VITE_BASE_URL}/organizations/${orgId}/events`,
     {
       headers: {
-        authorization: `Bearer ${localStorage.getItem("token")}`,
+        Authorization: `Bearer ${localStorage.getItem("token")}`,
       },
     }
   );
   return response.data;
 };
+
 export const getAnEventInAnOrganization = async function (
   orgId: number,
   eventId: number
@@ -102,7 +122,7 @@ export const getAnEventInAnOrganization = async function (
     `${import.meta.env.VITE_BASE_URL}/organizations/${orgId}/events/${eventId}`,
     {
       headers: {
-        authorization: `Bearer ${localStorage.getItem("token")}`,
+        Authorization: `Bearer ${localStorage.getItem("token")}`,
       },
     }
   );

--- a/client/src/components/AddModal/AddEvent.tsx
+++ b/client/src/components/AddModal/AddEvent.tsx
@@ -1,0 +1,230 @@
+import {
+    Button,
+    FormControl,
+    FormLabel,
+    HStack,
+    Icon,
+    Input,
+    Modal,
+    ModalBody,
+    ModalCloseButton,
+    ModalContent,
+    ModalFooter,
+    ModalHeader,
+    ModalOverlay,
+    useToast,
+} from "@chakra-ui/react";
+import { AiOutlineClose, AiOutlineCheckCircle } from "react-icons/ai";
+import { useMutation, useQueryClient } from "react-query";
+import { AddEventComponent } from "./types";
+import { useState } from "react";
+import { createEventInATeam } from "../../api/events.api";
+import { iEvent } from "../../interfaces/events.interface";
+
+// TODO: We currently get the target org and team from props but maybe we should get them from the redux store?
+// To avoid having to pass them down from the parent component in various places.
+const AddEvent: AddEventComponent = ({ orgId, orgName, teamId, teamName = "", isOpen, onClose }) => {
+    const [name, setName] = useState<string>("");
+    const [description, setDescription] = useState<string>("");
+    const [startDateTime, setStartDateTime] = useState<string>("1970-01-01T00:00:00");
+    const [endDateTime, setEndDateTime] = useState<string>("1970-01-01T00:00:00");
+    const [addressStreet, setAddressStreet] = useState<string>("");
+    const [addressCity, setAddressCity] = useState<string>("");
+    const [addressState, setAddressState] = useState<string>("");
+    const [addressZip, setAddressZip] = useState<string>("");
+
+    const toast = useToast();
+    const queryClient = useQueryClient();
+
+    const handleAdd = () => {
+        const data: Omit<iEvent, "created_by_user_id" | "event_id" | "organization_name" | "team_name" | "created_at" | "updated_at"> = {
+            event_name: name,
+            event_description: description,
+            organization_id: orgId || -1,
+            team_id: teamId || -1,
+            start_time: new Date(startDateTime),
+            end_time: new Date(endDateTime),
+            address_street: addressStreet,
+            address_city: addressCity,
+            address_state: addressState,
+            address_zipcode: addressZip,
+        };
+        mutation.mutate(data);
+        cleanUp();
+    };
+
+    const mutation = useMutation({
+        mutationFn: (
+            data: Omit<iEvent, "created_by_user_id" | "event_id" | "organization_name" | "team_name" | "created_at" | "updated_at">
+        ) => {
+            return createEventInATeam(data);
+        },
+        onSuccess: () => {
+            toast({
+                status: "success",
+                title: "Added Event!",
+            });
+            queryClient.invalidateQueries({ queryKey: "getEvents" });
+            mutation.reset();
+        },
+        onError: (err: Error) => {
+            toast({
+                status: "error",
+                title: "Error adding the event, please try again.",
+                description: err.message,
+            });
+        }
+    });
+
+    // Restore original state and close the modal
+    function cleanUp(): void {
+        setName("");
+        setDescription("");
+        setStartDateTime("1970-01-01T00:00:00");
+        setEndDateTime("1970-01-01T00:00:00");
+        setAddressStreet("");
+        setAddressCity("");
+        setAddressState("");
+        setAddressZip("");
+        onClose();
+    }
+
+    return (
+        <Modal
+            isOpen={isOpen}
+            onClose={onClose}
+            isCentered
+            size={{ base: "full", md: "lg" }}
+            variant={"outline"}
+            closeOnOverlayClick={false}
+            closeOnEsc={false}
+        >
+            <ModalOverlay />
+            <ModalContent>
+                <ModalCloseButton />
+                <ModalHeader>Add Event to {teamName ?
+                    `${orgName} - ${teamName}` : orgName}</ModalHeader>
+                <ModalBody>
+                    {/* TODO: Add form validation and error messages */}
+                    <FormControl isRequired>
+                        <FormLabel>Event Name</FormLabel>
+                        <Input
+                            type={"text"}
+                            value={name}
+                            min={1}
+                            max={150}
+                            placeholder={"Event Name"}
+                            pattern={encodeURIComponent("[A-Za-z0-9!.,-]{1,150}")}
+                            onChange={(e) => setName(e.target.value)}
+                        />
+                    </FormControl>
+                    <FormControl isRequired>
+                        <FormLabel>Event Description</FormLabel>
+                        <Input
+                            type={"text"}
+                            value={description}
+                            min={1}
+                            max={65535} // mysql TEXT field upper limit: 65,535 characters
+                            placeholder={"Event Name"}
+                            pattern={encodeURIComponent("[A-Za-z0-9!.,-]{1,65535}")}
+                            onChange={(e) => setDescription(e.target.value)}
+                        />
+                    </FormControl>
+                    <strong>Event Address</strong>
+                    <FormControl isRequired>
+                        <FormLabel>Street</FormLabel>
+                        <Input
+                            type={"text"}
+                            value={addressStreet}
+                            min={1}
+                            max={100}
+                            placeholder={"Event Address - Street"}
+                            pattern={encodeURIComponent("[A-Za-z0-9.,-]{1,100}")}
+                            onChange={(e) => setAddressStreet(e.target.value)}
+                        />
+                    </FormControl>
+                    <FormControl isRequired>
+                        <FormLabel>City</FormLabel>
+                        <Input
+                            type={"text"}
+                            value={addressCity}
+                            min={1}
+                            max={100}
+                            placeholder={"Event Address - Ctiy"}
+                            pattern={encodeURIComponent("[A-Za-z.,-]{1,100}")}
+                            onChange={(e) => setAddressCity(e.target.value)}
+                        />
+                    </FormControl>
+                    <FormControl isRequired>
+                        <FormLabel>State</FormLabel>
+                        <Input
+                            type={"text"}
+                            value={addressState}
+                            min={1}
+                            max={100}
+                            placeholder={"Event Address - State"}
+                            pattern={encodeURIComponent("[A-Za-z.,-]{1,100}")}
+                            onChange={(e) => setAddressState(e.target.value)}
+                        />
+                    </FormControl>
+                    <FormControl isRequired>
+                        <FormLabel>Zip Code</FormLabel>
+                        <Input
+                            type={"text"}
+                            value={addressZip}
+                            min={1}
+                            max={100}
+                            placeholder={"Event Address - Zip Code"}
+                            pattern={encodeURIComponent("[0-9-]{1,100}")}
+                            onChange={(e) => setAddressZip(e.target.value)}
+                        />
+                    </FormControl>
+                    <FormControl isRequired>
+                        <FormLabel>Start Date & Time</FormLabel>
+                        <Input
+                            type={"datetime-local"}
+                            value={startDateTime}
+                            placeholder={"Event Start Date"}
+                            onChange={(e) => setStartDateTime(e.target.value)}
+                        />
+                    </FormControl>
+                    <FormControl isRequired>
+                        <FormLabel>End Date & Time</FormLabel>
+                        <Input
+                            type={"datetime-local"}
+                            value={endDateTime}
+                            placeholder={"Event End Date"}
+                            onChange={(e) => setEndDateTime(e.target.value)}
+                        />
+                    </FormControl>
+                </ModalBody>
+                <ModalFooter>
+                    <HStack
+                        width={{ base: "100%", md: "50%" }}
+                        justifyContent={"space-between"}
+                    >
+                        <Button
+                            colorScheme="gray"
+                            width={"100%"}
+                            justifyContent={"space-between"}
+                            variant={"outline"}
+                            onClick={onClose}
+                        >
+                            Cancel <Icon as={AiOutlineClose} />
+                        </Button>
+                        <Button
+                            colorScheme="purple"
+                            justifyContent={"space-between"}
+                            width={"100%"}
+                            onClick={handleAdd}
+                        >
+                            Add <Icon as={AiOutlineCheckCircle} />
+                        </Button>
+                    </HStack>
+                </ModalFooter>
+            </ModalContent>
+        </Modal>
+    );
+};
+
+export default AddEvent;

--- a/client/src/components/AddModal/types.ts
+++ b/client/src/components/AddModal/types.ts
@@ -12,5 +12,15 @@ interface AddTeamProps {
   onClose: () => void;
 }
 
+interface AddEventProps {
+  isOpen: boolean;
+  orgId: number;
+  orgName: string;
+  teamId: number;
+  teamName: string;
+  onClose: () => void;
+}
+
 export type AddOrgComponent = FunctionComponent<AddOrgProps>;
 export type AddTeamComponent = FunctionComponent<AddTeamProps>;
+export type AddEventComponent = FunctionComponent<AddEventProps>;

--- a/client/src/hooks/formatDate.ts
+++ b/client/src/hooks/formatDate.ts
@@ -1,3 +1,8 @@
+/**
+ * Converts a JS Date to a human readable string in the format "YY-MM-DD HH:MM AM/PM"
+ * @param date 
+ * @returns string in the format "YY-MM-DD HH:MM AM/PM"
+ */
 export const formatDate = (date: Date) => {
   const year = date.getFullYear().toString().slice(-2);
   const month = ("0" + (date.getMonth() + 1)).slice(-2); // Months are zero-based
@@ -15,6 +20,12 @@ export const formatDate = (date: Date) => {
   return formattedDate;
 };
 
+
+/**
+ * Converts a JS Date to a MySQL timestamp string in the format "YYYY-MM-DD HH:MM:SS"
+ * @param date 
+ * @returns string in the format "YYYY-MM-DD HH:MM:SS"
+ */
 export const formatSQLDate = (date: Date) => {
   const year = date.getFullYear().toString();
   const month = ("0" + (date.getMonth() + 1)).slice(-2);
@@ -27,3 +38,29 @@ export const formatSQLDate = (date: Date) => {
 
   return formattedDate;
 };
+
+/**
+ * Convert a MySQL timestamp to a JS Date object
+ * @param timestamp string in the format "YYYY-MM-DD HH:MM:SS"
+ * @returns Date object
+ */
+export const timestampToDate = (timestamp: string) => {
+  // MySQL timestamps have the format "YYYY-MM-DD HH:MM:SS"
+  // Split the timestamp into date and time components
+  const [date, time] = timestamp.split(" ");
+
+  // Split the date into year, month, and day components
+  const [year, month, day] = date.split("-");
+  // Split the time into hour, minute, and second components
+  const [hour, minute, second] = time.split(":");
+
+  // Create a new Date object with the components
+  return new Date(
+    parseInt(year),
+    parseInt(month) - 1, // Months are zero-based so January is 0 and December is 11
+    parseInt(day),
+    parseInt(hour),
+    parseInt(minute),
+    parseInt(second)
+  );
+}

--- a/client/src/interfaces/events.interface.ts
+++ b/client/src/interfaces/events.interface.ts
@@ -45,7 +45,8 @@ export interface iGetEventsJoinTeamJoinOrg {
   success: boolean;
   events: iEventJoinTeamJoinOrg[];
 }
-export interface iGetEvent {
+
+export interface iCreateEventInATeam {
   success: boolean;
-  event: iEvent;
+  event_id: number;
 }

--- a/client/src/views/Events/EventCards.tsx
+++ b/client/src/views/Events/EventCards.tsx
@@ -23,7 +23,7 @@ const EventCards: EventCardsComponent = () => {
   return (
     <Stack display={{ base: "initial", md: "none" }}>
       {events.map((e) => (
-        <Card backgroundColor={bgCardColor} color={textCardColor}>
+        <Card backgroundColor={bgCardColor} color={textCardColor} key={e.event_id}>
           <CardFooter
             width={"100%"}
             alignItems={"center"}

--- a/client/src/views/Events/EventCards.tsx
+++ b/client/src/views/Events/EventCards.tsx
@@ -23,7 +23,7 @@ const EventCards: EventCardsComponent = () => {
   return (
     <Stack display={{ base: "initial", md: "none" }}>
       {events.map((e) => (
-        <Card backgroundColor={bgCardColor} color={textCardColor} key={e.event_id}>
+        <Card backgroundColor={bgCardColor} color={textCardColor} key={"CardEventID" + e.event_id}>
           <CardFooter
             width={"100%"}
             alignItems={"center"}

--- a/client/src/views/Events/EventFilters.tsx
+++ b/client/src/views/Events/EventFilters.tsx
@@ -66,7 +66,7 @@ export const OrgFilter: OrgFilterComponent = () => {
           >
             {organizations &&
               organizations.map((org) => (
-                <option key={org.id} value={org.id}>
+                <option key={"EventFiltersOrgId" + org.id} value={org.id}>
                   {org.name}
                 </option>
               ))}
@@ -96,7 +96,7 @@ export const OrgFilter: OrgFilterComponent = () => {
           <option value={0}>No team selected</option>
           {teams &&
             teams.map((team) => (
-              <option key={team.id} value={team.id}>
+              <option key={"EventFiltersTeamId" + team.id} value={team.id}>
                 {team.name}
               </option>
             ))}

--- a/client/src/views/Events/EventFilters.tsx
+++ b/client/src/views/Events/EventFilters.tsx
@@ -8,13 +8,26 @@ import {
   setTeam,
 } from "../../features/Organizations/organizationSlice";
 import { useQueryClient } from "react-query";
+import AddOrg from "../../components/AddModal/AddOrg";
+import AddTeam from "../../components/AddModal/AddTeam";
+import { useDisclosure } from "@chakra-ui/react";
 
 export const OrgFilter: OrgFilterComponent = () => {
-  const { organizations, teams } = useAppSelector(
+  const { organizations, teams, selectedOrg, selectedTeam } = useAppSelector(
     (state) => state.organizations
   );
+
+  const selectedOrgName = useAppSelector((state) =>
+    state.organizations.organizations.find(
+      (org) => org.id === state.organizations.selectedOrg
+    )?.name
+  );
+
   const dispatch = useAppDispatch();
   const queryClient = useQueryClient();
+
+  const { isOpen: isAddOrgOpen, onOpen: onAddOrgOpen, onClose: onAddOrgClose } = useDisclosure();
+  const { isOpen: isAddTeamOpen, onOpen: onAddTeamOpen, onClose: onAddTeamClose } = useDisclosure();
 
   function handleSelectOrg(e: ChangeEvent<HTMLSelectElement>) {
     dispatch(setOrg(+e.target.value));
@@ -42,12 +55,14 @@ export const OrgFilter: OrgFilterComponent = () => {
               marginLeft={"5px"}
               marginBottom={"6px"}
               size="xs"
+              onClick={onAddOrgOpen}
             />
           </HStack>
           <Select
             width={{ base: "50%", md: "200px" }}
             mb={"10px"}
             onChange={(e) => handleSelectOrg(e)}
+            defaultValue={selectedOrg}
           >
             {organizations &&
               organizations.map((org) => (
@@ -69,12 +84,13 @@ export const OrgFilter: OrgFilterComponent = () => {
             marginLeft={"5px"}
             marginBottom={"10px"}
             size="xs"
+            onClick={onAddTeamOpen}
           />
         </HStack>
         <Select
           width={{ base: "50%", md: "200px" }}
           marginBottom={"10px"}
-          defaultValue={0}
+          defaultValue={selectedTeam || 0}
           onChange={(e) => handleSelectTeam(e)}
         >
           <option value={0}>No team selected</option>
@@ -86,6 +102,12 @@ export const OrgFilter: OrgFilterComponent = () => {
             ))}
         </Select>
       </Stack>
+      {/* TODO: Adding an org here does not refresh the list of orgs in the dropdown */}
+      <AddOrg isOpen={isAddOrgOpen} onClose={onAddOrgClose} />
+      {selectedOrg && organizations.length > 0 &&
+        <AddTeam isOpen={isAddTeamOpen} onClose={onAddTeamClose}
+          orgId={selectedOrg} orgName={selectedOrgName || ""} />
+      }
     </Stack>
   );
 };

--- a/client/src/views/Events/EventList.tsx
+++ b/client/src/views/Events/EventList.tsx
@@ -11,24 +11,43 @@ import { AddIcon } from "@chakra-ui/icons";
 import { EventTable } from "./EventTable";
 import EventCards from "./EventCards";
 import { useAppSelector } from "../../app/hooks";
+import { useDisclosure } from "@chakra-ui/hooks";
+import AddEvent from "../../components/AddModal/AddEvent";
+import OrganizationContext from "../Organizations/OrganizationContext";
+import { useContext } from "react";
+
+import { iTeam } from "../../interfaces/teams.interface";
 
 const EventList: EventsListComponent = () => {
-  const { events } = useAppSelector((state) => state.organizations);
+  // Need to know the org and team we're working with
+  // TODO: This information could be retrieved from the redux store, context or props?
+  const { orgData, teamsData } = useContext(OrganizationContext);
 
+  const { events, selectedOrg, selectedTeam } = useAppSelector((state) => state.organizations);
+
+  // Get the selected team's name to display in the header
+  const selectedTeamName = teamsData?.teams.find(
+    (team: iTeam) => team.id === selectedTeam
+  )?.name;
+
+  const { isOpen, onOpen, onClose } = useDisclosure();
+  
   return (
     <>
       <Stack>
         <HStack>
           <Heading size={"md"} mb={"5px"}>
-            Events
+            All Events
           </Heading>
         </HStack>
+        {/* TODO: Limit this to admins/authorized users */}
         <Heading size={"sm"}>Add an Event</Heading>
         <IconButton
           aria-label="Create new event"
           icon={<AddIcon />}
           marginLeft={"5px"}
           size="md"
+          onClick={onOpen}
         />
       </Stack>
       {events && events.length == 0 && (
@@ -41,10 +60,14 @@ const EventList: EventsListComponent = () => {
       )}
       {events && events.length > 0 && (
         <>
-          <EventTable />
+          <EventTable showTeamName={true} />
           <EventCards />
         </>
       )}
+      {/* TODO: Don't show the Add Event option for unauthorized users */}
+      <AddEvent orgId={selectedOrg} orgName={orgData?.name || ""}
+        teamId={selectedTeam} teamName={selectedTeamName || ""}
+        isOpen={isOpen} onClose={onClose} />
     </>
   );
 };

--- a/client/src/views/Events/EventTable.tsx
+++ b/client/src/views/Events/EventTable.tsx
@@ -41,63 +41,61 @@ export const EventTable: EventTableComponent = ({ showTeamName = false, ...rest 
         </Thead>
         <Tbody>
           {events.map((e) => (
-            <>
-              <Tr>
-                <Td>
-                  {/* TODO: For some reason the events have a .name instead of .event_name here */}
-                  {e.event_name || "Unnamed Event"}
-                  {new Date(Date.now()) > new Date(e.end_time) ? (
-                    <Badge
-                      marginLeft={"5px"}
-                      fontSize="xx-small"
-                      colorScheme="orange"
-                    >
-                      Completed
-                    </Badge>
-                  ) : (
-                    <Badge
-                      marginLeft={"5px"}
-                      fontSize="xx-small"
-                      colorScheme="green"
-                    >
-                      Upcoming
-                    </Badge>
-                  )}
-                </Td>
-                {showTeamName && <Td>{e.team_name}</Td>}
-                <Td>
-                  <>
-                    {/* TODO: For some reason the events don't have date keys here */}
-                    <div style={{ display: "block" }}>
-                      <Text fontSize="xs">
-                        {new Date(e.start_time).toDateString()}
-                      </Text>
-                    </div>
-                    <div style={{ display: "block" }}>
-                      <Text fontSize="md">
-                        {new Date(e.start_time).toLocaleTimeString()} to{" "}
-                        {new Date(e.end_time).toLocaleTimeString()}
-                      </Text>
-                    </div>
-                  </>
-                </Td>
-                <Td>{e.event_description}</Td>
-                <Td>
-                  {e.address_street}, {e.address_city}, {e.address_state}{" "}
-                  {e.address_zipcode}
-                </Td>
-                <Td>
-                  <Button
-                    as={RouterLink}
-                    variant="solid"
-                    size={"sm"}
-                    to={"/d" + "/" + selectedOrg + "/" + e?.event_id}
+            <Tr key={"EventTableTd" + e.event_id}>
+              <Td>
+                {/* TODO: For some reason the events have a .name instead of .event_name here */}
+                {e.event_name || "Unnamed Event"}
+                {new Date(Date.now()) > new Date(e.end_time) ? (
+                  <Badge
+                    marginLeft={"5px"}
+                    fontSize="xx-small"
+                    colorScheme="orange"
                   >
-                    View Event
-                  </Button>
-                </Td>
-              </Tr>
-            </>
+                    Completed
+                  </Badge>
+                ) : (
+                  <Badge
+                    marginLeft={"5px"}
+                    fontSize="xx-small"
+                    colorScheme="green"
+                  >
+                    Upcoming
+                  </Badge>
+                )}
+              </Td>
+              {showTeamName && <Td>{e.team_name}</Td>}
+              <Td>
+                <>
+                  {/* TODO: For some reason the events don't have date keys here */}
+                  <div style={{ display: "block" }}>
+                    <Text fontSize="xs">
+                      {new Date(e.start_time).toDateString()}
+                    </Text>
+                  </div>
+                  <div style={{ display: "block" }}>
+                    <Text fontSize="md">
+                      {new Date(e.start_time).toLocaleTimeString()} to{" "}
+                      {new Date(e.end_time).toLocaleTimeString()}
+                    </Text>
+                  </div>
+                </>
+              </Td>
+              <Td>{e.event_description}</Td>
+              <Td>
+                {e.address_street}, {e.address_city}, {e.address_state}{" "}
+                {e.address_zipcode}
+              </Td>
+              <Td>
+                <Button
+                  as={RouterLink}
+                  variant="solid"
+                  size={"sm"}
+                  to={"/d" + "/" + selectedOrg + "/" + e?.event_id}
+                >
+                  View Event
+                </Button>
+              </Td>
+            </Tr>
           ))}
         </Tbody>
       </Table>

--- a/client/src/views/Events/EventTable.tsx
+++ b/client/src/views/Events/EventTable.tsx
@@ -14,11 +14,13 @@ import { Link as RouterLink } from "react-router-dom";
 import { EventTableComponent } from "./types";
 import { useAppSelector } from "../../app/hooks";
 
-export const EventTable: EventTableComponent = ({ ...rest }) => {
+export const EventTable: EventTableComponent = ({ showTeamName = false, ...rest }) => {
   const { events, selectedOrg } = useAppSelector(
     (state) => state.organizations
   );
-  console.log(events[0]);
+
+  console.log("Events pulled from Redux in EventsTable: ", events);
+
   return (
     <TableContainer
       {...rest}
@@ -30,6 +32,7 @@ export const EventTable: EventTableComponent = ({ ...rest }) => {
         <Thead>
           <Tr>
             <Th>Name</Th>
+            {showTeamName && <Th>Team</Th>}
             <Th>Date & Time</Th>
             <Th>Description</Th>
             <Th>Location</Th>
@@ -41,7 +44,8 @@ export const EventTable: EventTableComponent = ({ ...rest }) => {
             <>
               <Tr>
                 <Td>
-                  {e.event_name}
+                  {/* TODO: For some reason the events have a .name instead of .event_name here */}
+                  {e.event_name || "Unnamed Event"}
                   {new Date(Date.now()) > new Date(e.end_time) ? (
                     <Badge
                       marginLeft={"5px"}
@@ -60,8 +64,10 @@ export const EventTable: EventTableComponent = ({ ...rest }) => {
                     </Badge>
                   )}
                 </Td>
+                {showTeamName && <Td>{e.team_name}</Td>}
                 <Td>
                   <>
+                    {/* TODO: For some reason the events don't have date keys here */}
                     <div style={{ display: "block" }}>
                       <Text fontSize="xs">
                         {new Date(e.start_time).toDateString()}
@@ -85,7 +91,7 @@ export const EventTable: EventTableComponent = ({ ...rest }) => {
                     as={RouterLink}
                     variant="solid"
                     size={"sm"}
-                    to={"/d" + "/" + selectedOrg + "/" + e.event_id}
+                    to={"/d" + "/" + selectedOrg + "/" + e?.event_id}
                   >
                     View Event
                   </Button>

--- a/client/src/views/Events/Tasks/TaskCard.tsx
+++ b/client/src/views/Events/Tasks/TaskCard.tsx
@@ -87,7 +87,7 @@ const TaskCard: TaskCardComponent = ({ task }) => {
   return (
     <>
       <Card
-        key={task.id}
+        key={"EventTaskId" + task.id}
         height={"100%"}
         direction={"row"}
         align={"center"}

--- a/client/src/views/Events/Tasks/TaskList.tsx
+++ b/client/src/views/Events/Tasks/TaskList.tsx
@@ -9,7 +9,7 @@ const TaskList: TaskListComponent = ({ tasks, isLoading }) => {
         <SimpleGrid columns={1} gap={5}>
           {[1, 2, 3].map((index) => (
             <Skeleton
-              key={index}
+              key={"TaskGridIdx" + index}
               width={"400px"}
               height={"60px"}
               isLoaded={isLoading}
@@ -18,7 +18,7 @@ const TaskList: TaskListComponent = ({ tasks, isLoading }) => {
         </SimpleGrid>
       ) : (
         <SimpleGrid columns={1} gap={3}>
-          {tasks && tasks.map((task) => <TaskCard key={task.id} task={task} />)}
+          {tasks && tasks.map((task) => <TaskCard key={"TaskGridId" + task.id} task={task} />)}
         </SimpleGrid>
       )}
     </Stack>

--- a/client/src/views/Events/index.tsx
+++ b/client/src/views/Events/index.tsx
@@ -22,12 +22,25 @@ import {
 } from "../../features/Organizations/organizationSlice";
 import { EventTable } from "./EventTable";
 import EventCards from "./EventCards";
+import AddEvent from "../../components/AddModal/AddEvent";
+import { useDisclosure } from "@chakra-ui/hooks";
 
 const EventsView = () => {
   const { events, selectedOrg, selectedTeam } = useAppSelector(
     (state) => state.organizations
   );
+
+  const selectedOrgName = useAppSelector((state) =>
+    state.organizations.organizations.find((org) => org.id === state.organizations.selectedOrg)?.name
+  );
+
+  const selectedTeamName = useAppSelector((state) =>
+    state.organizations.teams.find((team) => team.id === state.organizations.selectedTeam)?.name
+  );
+
   const dispatch = useAppDispatch();
+
+  const { isOpen, onOpen, onClose } = useDisclosure();
 
   useQuery({
     queryKey: ["getOrgs"],
@@ -60,7 +73,7 @@ const EventsView = () => {
       refetchTeams();
       refetchEvents();
     }
-  }, [selectedTeam, selectedOrg, refetchTeams, refetchEvents]);
+  }, [selectedTeam, selectedOrg]);
 
   return (
     <Flex gap={8} flexDir={{ base: "column", md: "row" }}>
@@ -71,6 +84,7 @@ const EventsView = () => {
         <Stack>
           <Heading size={"md"}>Events</Heading>
           <Stack alignItems={"center"}>
+          {selectedTeam !== 0 && (
             <HStack width={"100%"} alignItems={"center"}>
               <Heading size={"xs"} mb={"5px"}>
                 Add an Event
@@ -81,11 +95,13 @@ const EventsView = () => {
                 marginLeft={"5px"}
                 marginBottom={"6px"}
                 size="xs"
+                onClick={onOpen}
               />
             </HStack>
+            )}
           </Stack>
         </Stack>
-        {events && events.length == 0 && (
+        {selectedTeam !== 0 && events && events.length == 0 && (
           <Stack spacing={3}>
             <Alert status="info">
               <AlertIcon />
@@ -110,6 +126,9 @@ const EventsView = () => {
           </>
         )}
       </Stack>
+      <AddEvent orgId={selectedOrg} orgName={selectedOrgName || ""}
+        teamId={selectedTeam} teamName={selectedTeamName || ""}
+        isOpen={isOpen} onClose={onClose} />
     </Flex>
   );
 };

--- a/client/src/views/Events/types.ts
+++ b/client/src/views/Events/types.ts
@@ -20,9 +20,13 @@ interface EventsProps {
   onTeamChange: (e: ChangeEvent<HTMLSelectElement>) => void;
 }
 
-interface EventListProps {}
+interface EventListProps {
+  teamId?: number; // If we pass in a teamId, we want to only show events for that team
+}
 
-interface EventTableProps extends TableContainerProps {}
+interface EventTableProps extends TableContainerProps {
+  showTeamName?: boolean; // If true, show the team name in the table
+}
 
 interface EventCardsProps extends CardProps {}
 

--- a/client/src/views/Organizations/OrganizationMembers.tsx
+++ b/client/src/views/Organizations/OrganizationMembers.tsx
@@ -20,7 +20,7 @@ const OrganizationMembers = () => {
     <Stack width={"100%"} alignSelf={"start"}>
       <Heading size={"sm"}>Members: </Heading>
       {members?.map((member) => (
-        <Card bg={cardBg}>
+        <Card bg={cardBg} key={"OrgMemberCardName" + member.name}>
           <CardBody width={"100%"}>
             <HStack width={"100%"} justifyContent={"space-between"}>
               <HStack gap={5}>

--- a/client/src/views/Organizations/OrganizationPage.tsx
+++ b/client/src/views/Organizations/OrganizationPage.tsx
@@ -12,6 +12,7 @@ import OrganizationContext from "./OrganizationContext";
 import OrganizationEvents from "./OrganizationEvents";
 import { setOrg, setTeam, setTeams, setEvents } from "../../features/Organizations/organizationSlice";
 import { useAppDispatch, useAppSelector } from "../../app/hooks";
+import { useEffect } from "react";
 
 const FAKE_MEMBERS = [
   {
@@ -51,19 +52,23 @@ const OrganizationPage = () => {
     () => getEvents(+organizationId!)
   );
 
-  // Add organization teams to redux store
-  dispatch(setTeams(teamsData?.teams || []));
-  // Set the active organization in the redux store
-  dispatch(setOrg(+organizationId!));
   // Determine the currently active team, if one hasn't been chosen, use the organization-wide team
   const { selectedTeam } = useAppSelector((state) => state.organizations);
-  // By default, set the active team to the organization-wide team
-  if (selectedTeam === 0 && teamsData?.teams.length) {
-    console.log("Teams in this org: " + JSON.stringify(teamsData.teams));
-    // Searching for the name here because I'm not sure if the first element in the array is always the org-wide team
-    // TODO: This doesn't seem to be the most ideal way - what if the org-wide team name changes or something?
-    dispatch(setTeam(teamsData.teams.find((team) => team.name.includes("Organization-wide Team"))!.id));
-  }
+
+  // When the teams data is loaded, set the active team to the organization-wide team
+  useEffect(() => {
+    // Add organization teams to redux store
+    dispatch(setTeams(teamsData?.teams || []));
+    // Set the active organization in the redux store
+    dispatch(setOrg(+organizationId!));
+    // By default, set the active team to the organization-wide team
+    if (selectedTeam === 0 && teamsData && teamsData.teams.length > 0) {
+      console.log("Teams in this org: " + JSON.stringify(teamsData.teams));
+      // Searching for the name here because I'm not sure if the first element in the array is always the org-wide team
+      // TODO: This doesn't seem to be the most ideal way - what if the org-wide team name changes or something?
+      dispatch(setTeam(teamsData.teams.find((team) => team.name.includes("Organization-wide Team"))!.id));
+    }
+  }, [orgData, teamsData]); // eslint-disable-line react-hooks/exhaustive-deps
 
   return (
     <>

--- a/client/src/views/Organizations/OrganizationPage.tsx
+++ b/client/src/views/Organizations/OrganizationPage.tsx
@@ -10,6 +10,8 @@ import OrganizationTeams from "./OrganizationTeams";
 import OrganizationMembers from "./OrganizationMembers";
 import OrganizationContext from "./OrganizationContext";
 import OrganizationEvents from "./OrganizationEvents";
+import { setOrg, setTeam, setTeams, setEvents } from "../../features/Organizations/organizationSlice";
+import { useAppDispatch, useAppSelector } from "../../app/hooks";
 
 const FAKE_MEMBERS = [
   {
@@ -32,6 +34,8 @@ const FAKE_MEMBERS = [
 const OrganizationPage = () => {
   const { organizationId } = useParams();
 
+  const dispatch = useAppDispatch();
+
   const { data: orgData, isLoading: orgLoading } = useQuery(
     "getOrganization",
     () => getOrganization(+organizationId!)
@@ -47,7 +51,19 @@ const OrganizationPage = () => {
     () => getEvents(+organizationId!)
   );
 
-  console.log(eventsData);
+  // Add organization teams to redux store
+  dispatch(setTeams(teamsData?.teams || []));
+  // Set the active organization in the redux store
+  dispatch(setOrg(+organizationId!));
+  // Determine the currently active team, if one hasn't been chosen, use the organization-wide team
+  const { selectedTeam } = useAppSelector((state) => state.organizations);
+  // By default, set the active team to the organization-wide team
+  if (selectedTeam === 0 && teamsData?.teams.length) {
+    console.log("Teams in this org: " + JSON.stringify(teamsData.teams));
+    // Searching for the name here because I'm not sure if the first element in the array is always the org-wide team
+    // TODO: This doesn't seem to be the most ideal way - what if the org-wide team name changes or something?
+    dispatch(setTeam(teamsData.teams.find((team) => team.name.includes("Organization-wide Team"))!.id));
+  }
 
   return (
     <>

--- a/client/src/views/Organizations/OrganizationTeams.tsx
+++ b/client/src/views/Organizations/OrganizationTeams.tsx
@@ -19,6 +19,7 @@ const OrganizationTeams = () => {
   return (
     <Stack alignSelf={"start"} width={"100%"}>
       <Heading size={"sm"}>Teams: </Heading>
+      {/* TODO: 'Add Team' button here? */}
       {teamsLoading && (
         <Skeleton
           width={"100%"}

--- a/client/src/views/Organizations/OrganizationTeams.tsx
+++ b/client/src/views/Organizations/OrganizationTeams.tsx
@@ -31,26 +31,23 @@ const OrganizationTeams = () => {
       {/* will add table for desktop later */}
       {teamsData &&
         teamsData.teams.map((team) => (
-          <>
-            <Card
-              width={"100%"}
-              align={"center"}
-              justifyContent={"space-between"}
-              display={{ base: "flex", md: "flex" }}
-              bg={cardBg}
-            >
-              <CardBody width={"100%"}>
-                <HStack width={"100%"} justifyContent={"space-between"}>
-                  <Heading size={"sm"}>{team.name}</Heading>
-
-                  <Button gap={3} alignSelf={"end"}>
-                    Go to Team Page
-                    <Icon as={ChevronRightIcon} />
-                  </Button>
-                </HStack>
-              </CardBody>
-            </Card>
-          </>
+          <Card key={"OrgTeamCardId" + team.id}
+            width={"100%"}
+            align={"center"}
+            justifyContent={"space-between"}
+            display={{ base: "flex", md: "flex" }}
+            bg={cardBg}
+          >
+            <CardBody width={"100%"}>
+              <HStack width={"100%"} justifyContent={"space-between"}>
+                <Heading size={"sm"}>{team.name}</Heading>
+                <Button gap={3} alignSelf={"end"}>
+                  Go to Team Page
+                  <Icon as={ChevronRightIcon} />
+                </Button>
+              </HStack>
+            </CardBody>
+          </Card>
         ))}
     </Stack>
   );

--- a/client/src/views/Organizations/Organizations.tsx
+++ b/client/src/views/Organizations/Organizations.tsx
@@ -54,16 +54,14 @@ const Organizations: OrganizationsComponent = ({ organizations }) => {
                 </Thead>
                 <Tbody>
                   {organizations.map((org) => (
-                    <>
-                      <OrganizationTd organization={org} key={org.id} />
-                    </>
+                    <OrganizationTd organization={org} key={"OrgTdId" + org.id} />
                   ))}
                 </Tbody>
               </Table>
             </TableContainer>
             <Stack display={{ base: "flex", md: "none" }} gap={5}>
               {organizations.map((org) => (
-                <OrganizationCard organization={org} key={org.id} />
+                <OrganizationCard organization={org} key={"OrgCardId" + org.id} />
               ))}
             </Stack>
           </>

--- a/server/database/seed.sql
+++ b/server/database/seed.sql
@@ -125,7 +125,7 @@ INSERT INTO organizations (owner_user_id, name, website_url, phone_number, logo_
   (1, 'test_org', 'https://testorg.com', '+123456789', 'https://testorg.com/logo.png');
 
 INSERT INTO permissions (user_id, organization_id, level) VALUES (1, 1, 0);
-INSERT INTO teams (organization_id, created_by_user_id, name) VALUES (1, 1, "Soup Kitchen");
+INSERT INTO teams (organization_id, created_by_user_id, name) VALUES (1, 1, "Organization-wide Team");
 INSERT INTO events (team_id, created_by_user_id, name, description, address_street, address_city, address_state, address_zipcode, start_time, end_time) VALUES
   (1, 1, 'test_event', 'Description for test_event', '1234 Test Street', 'test_city', 'test_state', '12345', '2023-08-28 10:00:00', '2023-08-28 15:00:00');
 INSERT INTO users_orgs (user_id, organization_id) VALUES (1, 1);

--- a/server/index.ts
+++ b/server/index.ts
@@ -11,7 +11,18 @@ import { organizationsRouter } from "./routes/organizations.routes";
 import { tasksRouter } from "./routes/tasks.routes";
 import { teamsRouter } from "./routes/teams.routes";
 import { userRouter } from "./routes/users.routes";
-dotenv.config();
+
+// Use the .env.development file in development
+if (process.env.NODE_ENV !== "production") {
+  // If a .env.development file exists, use it
+  dotenv.config({ path: ".env.development" });
+  // If there's no .env.development file, use .env
+  dotenv.config();
+} else {
+  dotenv.config({ path: ".env.production" });
+  // If there's .env but not .env.production, use .env
+  dotenv.config();
+}
 
 const app: Express = express();
 const port = process.env.PORT;

--- a/server/routes/auth.routes.ts
+++ b/server/routes/auth.routes.ts
@@ -137,9 +137,10 @@ router.post(
       await connection.end();
 
       // return token
-      res.status(200).json({ success: true, jwt: token });
+      return res.status(200).json({ success: true, jwt: token });
     } catch (error) {
-      res.status(500).json({ success: false });
+      console.log("POST /auth/login error: ", error);
+      return res.status(500).json({ success: false });
     }
   }
 );

--- a/server/routes/events.routes.ts
+++ b/server/routes/events.routes.ts
@@ -3,14 +3,18 @@ import { Request, Response, Router } from "express";
 import { body, validationResult } from "express-validator";
 import mysql, { RowDataPacket, ResultSetHeader } from "mysql2/promise";
 import decodeToken from "../middleware/token.middleware";
+import dateToMySQLTimestamp from "../utils/formatMySQLTimestamp";
 
 dotenv.config();
 const router: Router = Router();
 router.use(decodeToken);
 
 // TODO: Is this needed since events must be tied to a team?
+// Once the global-team function is implemented, we could use the teams endpoint to create an event
+// under the global team for this org and just provide the global team id, or we could keep this one and
+// determine the global team id from the passed org id
 //Create an event within an organization
-router.post(
+/* router.post(
   "/:organization_id/events",
   body("name").isString().trim(),
   body("description").isString().trim(),
@@ -53,14 +57,15 @@ router.post(
         req.body
       );
       await connection.end();
-      res
-        .status(200)
+      return res
+        .status(201)
         .json({ success: true, event_id: resultsInsertEvent.insertId });
     } catch (error) {
-      res.status(500).json({ success: false, error });
+      console.log("POST /organizations/:organization_id/events error: ", error);
+      return res.status(500).json({ success: false, error });
     }
   }
-);
+); */
 
 /**
  * @route GET /organizations/:organization_id/events
@@ -81,9 +86,10 @@ router.get("/:organization_id/events", async (req: Request, res: Response) => {
       [parseInt(req.params.organization_id)]
     );
     await connection.end();
-    res.status(200).json({ success: true, events: getEventsResults });
+    return res.status(200).json({ success: true, events: getEventsResults });
   } catch (error) {
-    res.status(500).json({ success: false, error });
+    console.log("GET /organizations/:organization_id/events error: ", error);
+    return res.status(500).json({ success: false, error });
   }
 });
 
@@ -110,9 +116,10 @@ router.get(
         throw { message: "No event found." };
       }
       await connection.end();
-      res.status(200).json({ success: true, event: getEventsResults[0] });
+      return res.status(200).json({ success: true, event: getEventsResults[0] });
     } catch (error) {
-      res.status(500).json({ success: false, error });
+      console.log("GET /organizations/:organization_id/events/:event_id error: ", error);
+      return res.status(500).json({ success: false, error });
     }
   }
 );
@@ -137,9 +144,10 @@ router.get(
         [parseInt(req.params.team_id), parseInt(req.params.event_id)]
       );
       await connection.end();
-      res.status(200).json({ success: true, events: getEventsResults });
+      return res.status(200).json({ success: true, events: getEventsResults });
     } catch (error) {
-      res.status(500).json({ success: false, error });
+      console.log("GET /organizations/:organization_id/teams/:team_id/events error: ", error);
+      return res.status(500).json({ success: false, error });
     }
   }
 );
@@ -165,11 +173,176 @@ router.get(
         [parseInt(req.params.team_id), parseInt(req.params.event_id)]
       );
       await connection.end();
-      res.status(200).json({ success: true, events: getEventsResults });
+      return res.status(200).json({ success: true, events: getEventsResults });
     } catch (error) {
-      res.status(500).json({ success: false, error });
+      console.log("GET /organizations/:organization_id/teams/:team_id/events/:event_id error: ", error);
+      return res.status(500).json({ success: false, error });
     }
   }
 );
+
+/**
+ * @route POST /organizations/:organization_id/events/:event_id
+ * @desc Create an event within an organization's team
+ * @param organization_id - The integer id of the organization
+ * @param team_id - The integer id of the team
+ * @returns { success: boolean, event_id: number }
+ */
+router.post(
+  "/:organization_id/teams/:team_id/events",
+  body("event_name").isString().trim(),
+  body("event_description").isString().trim(),
+  body("address_street").isString().trim(),
+  body("address_city").isString().trim(),
+  body("address_state").isString().trim(),
+  body("address_zipcode").isString().trim(),
+  body("start_time").isISO8601().trim(),
+  body("end_time").isISO8601().trim(),
+  async (req: Request, res: Response) => {
+    try {
+      let validationErrors = validationResult(req);
+      if (!validationErrors.isEmpty()) {
+        throw { validationErrors: validationErrors.array() };
+      }
+      // Check if the user has permission to write to the team's events
+      if (
+        req.permissions.filter((permission) => {
+          return (
+            permission.level <= 2 &&
+            permission.organization_id == parseInt(req.params.organization_id)
+          );
+        }).length == 0
+      ) {
+        console.log("User does not have permission to write to this resource, they have the following permissions: ", req.permissions)
+        throw {
+          message: "You do not have permission to write to this resource.",
+        };
+      }
+      req.body = {
+        ...req.body,
+        created_by_user_id: req.userId,
+        // The table expects event name and description to be called "name" and "description"
+        name: req.body.event_name,
+        description: req.body.event_description,
+        // Convert JS style Dates to MySQL style timestamps
+        start_time: dateToMySQLTimestamp(new Date(req.body.start_time)),
+        end_time: dateToMySQLTimestamp(new Date(req.body.end_time)),
+      };
+
+      // Remove the organization_id from the body, since it's not stored in the Events table
+      delete req.body.organization_id;
+      // Likewise, remove the unexpected event_name and event_description from the body
+      delete req.body.event_name;
+      delete req.body.event_description;
+
+      let connection = await mysql.createConnection(
+        process.env.DATABASE_URL as string
+      );
+      let insertEventQuery = `INSERT INTO events SET ?`;
+      const [resultsInsertEvent] = await connection.query<ResultSetHeader>(
+        insertEventQuery,
+        req.body
+      );
+      await connection.end();
+      return res
+        .status(201)
+        .json({ success: true, event_id: resultsInsertEvent.insertId });
+    } catch (error) {
+      console.log("POST /organizations/:organization_id/teams/:team_id/events error: ", error);
+      return res.status(500).json({ success: false, error });
+    }
+  }
+);
+
+/**
+ * @route PUT /organizations/:organization_id/teams/:team_id/events/:event_id
+ * @desc Update an event within an organization's team
+ * @param organization_id - The integer id of the organization
+ * @param team_id - The integer id of the team
+ * @param event_id - The integer id of the event
+ * @returns { success: boolean, event_id: number }
+ */
+router.put("/:organization_id/teams/:team_id/events/:event_id", async (req: Request, res: Response) => {
+  try {
+    // Check if the user has permission to write to the team's events
+    if (
+      req.permissions.filter((permission) => {
+        return (
+          permission.level <= 2 &&
+          permission.organization_id == parseInt(req.params.organization_id)
+        );
+      }).length == 0
+    ) {
+      throw {
+        message: "You do not have permission to write to this resource.",
+      };
+    }
+    // Remove the organization_id from the body, since it's not stored in the Events table
+    delete req.body.organization_id;
+    req.body = {
+      ...req.body,
+      created_by_user_id: req.userId,
+      // Convert JS style Dates to MySQL style timestamps
+      start_time: dateToMySQLTimestamp(new Date(req.body.start_time)),
+      end_time: dateToMySQLTimestamp(new Date(req.body.end_time)),
+    };
+    let connection = await mysql.createConnection(
+      process.env.DATABASE_URL as string
+    );
+    let updateEventQuery = `UPDATE events SET ? WHERE id = ?`;
+    const [resultsUpdateEvent] = await connection.query<ResultSetHeader>(
+      updateEventQuery,
+      [req.body, parseInt(req.params.event_id)]
+    );
+    await connection.end();
+    return res
+      .status(200)
+      .json({ success: true, event_id: resultsUpdateEvent.insertId });
+  } catch (error) {
+    console.log("PUT /organizations/:organization_id/teams/:team_id/events/:event_id error: ", error);
+    return res.status(500).json({ success: false, error });
+  }
+});
+
+/**
+ * @route DELETE /organizations/:organization_id/teams/:team_id/events/:event_id
+ * @desc Delete an event within an organization's team
+ * @param organization_id - The integer id of the organization
+ * @param team_id - The integer id of the team
+ * @param event_id - The integer id of the event
+ * @returns { success: boolean, event_id: number }
+ */
+router.delete("/:organization_id/teams/:team_id/events/:event_id", async (req: Request, res: Response) => {
+  try {
+    // Check if the user has permission to write to the team's events
+    if (
+      req.permissions.filter((permission) => {
+        return (
+          permission.level <= 2 &&
+          permission.organization_id == parseInt(req.params.organization_id)
+        );
+      }).length == 0
+    ) {
+      throw {
+        message: "You do not have permission to write to this resource.",
+      };
+    }
+    let connection = await mysql.createConnection(
+      process.env.DATABASE_URL as string
+    );
+    let deleteEventQuery = `DELETE FROM events WHERE id = ?`;
+    const [resultsDeleteEvent] = await connection.query<ResultSetHeader>(
+      deleteEventQuery,
+      [parseInt(req.params.event_id)]
+    );
+    await connection.end();
+    return res
+      .status(200)
+      .json({ success: true, event_id: resultsDeleteEvent.insertId });
+  } catch (error) {
+    console.log("DELETE /organizations/:organization_id/teams/:team_id/events/:event_id error: ", error);
+    return res.status(500).json({ success: false, error });
+  }
+});
 
 export { router as eventsRouter };

--- a/server/utils/formatMySQLTimestamp.ts
+++ b/server/utils/formatMySQLTimestamp.ts
@@ -1,0 +1,17 @@
+/**
+ * @name dateToMySQLTimestamp
+ * @desc This function will convert a JS Date object to a MySQL timestamp string.
+ * @param date 
+ * @returns A MySQL timestamp string in the format: YYYY-MM-DD HH:MM:SS
+ */
+export default function dateToMySQLTimestamp(date: Date): string {
+    // MySQL timestamp has the format: YYYY-MM-DD HH:MM:SS
+    // But JS dates have the format: YYYY-MM-DDTHH:MM:SSZ
+    // This function will convert a Date object to that format.
+
+    // This function will pad a number with leading zeros.
+    const padStartFn = (num: number) => String(num).padStart(2, '0');
+
+    // Return the formatted timestamp string like YYYY-MM-DD HH:MM:SS
+    return `${padStartFn(date.getFullYear())}-${padStartFn(date.getMonth() + 1)}-${padStartFn(date.getDate())} ${padStartFn(date.getHours())}:${padStartFn(date.getMinutes())}:${padStartFn(date.getSeconds())}`;
+}


### PR DESCRIPTION
* Upon creating an organization, a default team will be auto-created; events meant to be organization-wide or not tied to a more specific team will be applied to this "team."
* Minor formatting fixes throughout
* Incorporated Add Org., Add Team, and Add Event functions to Events Table view.
* Added unique key props to all rendered lists.
* Allowed Express to use a local .env.development so we can use local databases for testing while retaining the remote DB access in .env.production. Using only a .env for both environments should still function as normal.
* Added frontend API function to interface with backend Create Event within Org's Team endpoint.
* Added ability to show an event's parent team name via props to EventTable.
