### PR TITLE
Edit Orgs, Teams, and AddEvent fixes

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Vite + React + TS</title>
+    <title>%VITE_APP_NAME%</title>
   </head>
   <body>
     <div id="root"></div>

--- a/client/src/api/organizations.api.ts
+++ b/client/src/api/organizations.api.ts
@@ -45,9 +45,31 @@ export const addOrganization = async function (
   >
 ): Promise<iOrganization> {
   const token = localStorage.getItem("token");
-  if (!token) throw new Error("non token, please log in");
+  if (!token) throw new Error("no token, please log in");
   const response = await axios.post(
     `${import.meta.env.VITE_BASE_URL}/organizations`,
+    data,
+    {
+      headers: {
+        Authorization: "Bearer " + token,
+      },
+    }
+  );
+
+  return response.data;
+};
+
+export const editOrganization = async function (
+  organizationId: number,
+  data: Pick<
+    iOrganization,
+    "name" | "website_url" | "logo_url" | "phone_number"
+  >
+): Promise<iOrganization> {
+  const token = localStorage.getItem("token");
+  if (!token) throw new Error("no token, please log in");
+  const response = await axios.put(
+    `${import.meta.env.VITE_BASE_URL}/organizations/${organizationId}`,
     data,
     {
       headers: {

--- a/client/src/api/teams.api.ts
+++ b/client/src/api/teams.api.ts
@@ -64,3 +64,27 @@ export const getTeam = async function (
 
   return response.data;
 };
+
+// Edit/update a team within an organization
+export const editTeam = async function (
+  orgId: number,
+  teamId: number,
+  data: Pick<iTeam, "name">
+): Promise<iGetTeam> {
+  const token = localStorage.getItem("token");
+  if (!token)
+    throw new Error(
+      "No token found in teams.api@editTeam. Please login and try again."
+    );
+  const response = await axios.put<iGetTeam>(
+    `${import.meta.env.VITE_BASE_URL}/organizations/${orgId}/teams/${teamId}`,
+    data,
+    {
+      headers: {
+        Authorization: `Bearer ${token}`,
+      },
+    }
+  );
+
+  return response.data;
+};

--- a/client/src/components/AddModal/AddEvent.tsx
+++ b/client/src/components/AddModal/AddEvent.tsx
@@ -41,8 +41,8 @@ const AddEvent: AddEventComponent = ({ orgId, orgName, teamId, teamName = "", is
         const data: Omit<iEventJoinOrg, "created_by_user_id" | "event_id" | "organization_name" | "team_name" | "created_at" | "updated_at"> = {
             event_name: name,
             event_description: description,
-            organization_id: orgId || -1,
-            team_id: teamId || -1,
+            organization_id: orgId,
+            team_id: teamId,
             start_time: new Date(startDateTime),
             end_time: new Date(endDateTime),
             address_street: addressStreet,
@@ -63,7 +63,7 @@ const AddEvent: AddEventComponent = ({ orgId, orgName, teamId, teamName = "", is
         onSuccess: () => {
             toast({
                 status: "success",
-                title: "Added Event!",
+                title: "Added event successfully.",
             });
             queryClient.invalidateQueries({ queryKey: "getEvents" });
             mutation.reset();
@@ -126,7 +126,7 @@ const AddEvent: AddEventComponent = ({ orgId, orgName, teamId, teamName = "", is
                             value={description}
                             min={1}
                             max={65535} // mysql TEXT field upper limit: 65,535 characters
-                            placeholder={"Event Name"}
+                            placeholder={"Event Description"}
                             pattern={encodeURIComponent("[A-Za-z0-9!.,-]{1,65535}")}
                             onChange={(e) => setDescription(e.target.value)}
                         />

--- a/client/src/components/AddModal/AddEvent.tsx
+++ b/client/src/components/AddModal/AddEvent.tsx
@@ -21,6 +21,7 @@ import { useState } from "react";
 import { createEventInATeam } from "../../api/events.api";
 import { iEventJoinOrg } from "../../interfaces/events.interface";
 
+
 // TODO: We currently get the target org and team from props but maybe we should get them from the redux store?
 // To avoid having to pass them down from the parent component in various places.
 const AddEvent: AddEventComponent = ({ orgId, orgName, teamId, teamName = "", isOpen, onClose }) => {
@@ -150,7 +151,7 @@ const AddEvent: AddEventComponent = ({ orgId, orgName, teamId, teamName = "", is
                             value={addressCity}
                             min={1}
                             max={100}
-                            placeholder={"Event Address - Ctiy"}
+                            placeholder={"Event Address - City"}
                             pattern={encodeURIComponent("[A-Za-z.,-]{1,100}")}
                             onChange={(e) => setAddressCity(e.target.value)}
                         />

--- a/client/src/components/AddModal/AddTeam.tsx
+++ b/client/src/components/AddModal/AddTeam.tsx
@@ -45,29 +45,16 @@ const AddTeam: AddTeamComponent = ({ orgId, orgName, isOpen, onClose }) => {
     onSuccess: () => {
       toast({
         status: "success",
-        title: "Added Team!",
+        title: "Added team successfully.",
       });
-      console.log("Trying to refetch since we added a team")
-      // queryClient.invalidateQueries([
-      //   "getOrganizations",
-      //   "getEvents",
-      //   "getTeams",
-      // ]);
       queryClient.invalidateQueries({ queryKey: "getTeams" });
-      queryClient.invalidateQueries({ queryKey: "getOrganizations" });
       queryClient.invalidateQueries({ queryKey: "getEvents" });
-      // For some reason I couldn't get invalidateQueries to work with the array syntax,
-      // and also wasn't having success invalidating the getTeams query. Passing the refetch
-      // functions in via props from the parent component works, but I'm not sure if that's ideal.
-      // refetchEvents();
-      // refetchOrganizations();
-      // refetchTeams();
       mutation.reset();
     },
     onError: (err: Error) => {
       toast({
         status: "error",
-        title: "Error adding team",
+        title: "Error adding team, please try again.",
         description: err.message,
       });
     }

--- a/client/src/components/EditModal/EditOrg.tsx
+++ b/client/src/components/EditModal/EditOrg.tsx
@@ -1,0 +1,175 @@
+import {
+    Button,
+    FormControl,
+    FormLabel,
+    HStack,
+    Icon,
+    Input,
+    Modal,
+    ModalBody,
+    ModalCloseButton,
+    ModalContent,
+    ModalFooter,
+    ModalHeader,
+    ModalOverlay,
+    useToast,
+} from "@chakra-ui/react";
+import { AiOutlineClose, AiOutlineCheckCircle } from "react-icons/ai";
+import { useMutation, useQueryClient } from "react-query";
+import { EditOrgComponent } from "./types";
+import { useEffect, useState } from "react";
+import { iOrganization } from "../../interfaces/organization.interface";
+import { editOrganization } from "../../api/organizations.api";
+
+const EditOrgModal: EditOrgComponent = ({ org, isOpen, onClose }) => {
+    const [name, setName] = useState<string>(org?.name || "");
+    const [website, setWebsite] = useState<string>(org?.website_url || "");
+    const [phoneNumber, setPhoneNumber] = useState<string>(org?.phone_number || "");
+    const [logo, setLogo] = useState<string>(org?.logo_url || "");
+
+    // When we close and reopen the modal, or change the target org., we want to reset the form
+    useEffect(() => {
+        setName(org?.name || "");
+        setWebsite(org?.website_url || "");
+        setPhoneNumber(org?.phone_number || "");
+        setLogo(org?.logo_url || "");
+    }, [org]);
+
+    const toast = useToast();
+    const queryClient = useQueryClient();
+
+    const handleEdit = () => {
+        const data: Pick<
+            iOrganization,
+            "name" | "website_url" | "logo_url" | "phone_number"
+        > = {
+            name: name,
+            website_url: website,
+            logo_url: logo,
+            phone_number: phoneNumber,
+        };
+        mutation.mutate(data);
+        cleanUp();
+    };
+
+    const mutation = useMutation({
+        mutationFn: (
+            data: Pick<
+                iOrganization,
+                "name" | "website_url" | "logo_url" | "phone_number"
+            >
+        ) => {
+            return editOrganization(org.id, data);
+        },
+        onSuccess: () => {
+            toast({
+                title: "Organization edited successfully",
+                status: "success",
+                duration: 3000,
+                isClosable: true,
+            });
+            queryClient.invalidateQueries("getOrganization");
+            queryClient.invalidateQueries("getOrganizations");
+            queryClient.invalidateQueries("getTeams");
+            queryClient.invalidateQueries("getEvents");
+            mutation.reset();
+            cleanUp();
+        },
+        onError: (err: Error) => {
+            toast({
+                title: "Error editing organization. Please try again.",
+                description: err.message,
+                status: "error",
+            });
+            mutation.reset();
+        }
+    });
+
+    function cleanUp(): void {
+        setName("");
+        setWebsite("");
+        setPhoneNumber("");
+        setLogo("");
+        onClose();
+    }
+
+    return (
+        <Modal
+            isOpen={isOpen}
+            onClose={onClose}
+            isCentered
+            size={{ base: "full", md: "lg" }}
+            variant={"outline"}
+        >
+            <ModalOverlay />
+            <ModalContent>
+                <ModalCloseButton />
+                <ModalHeader>Edit Organization</ModalHeader>
+                <ModalBody>
+                    <FormControl isRequired>
+                        <FormLabel>Name</FormLabel>
+                        <Input
+                            type={"text"}
+                            value={name}
+                            min={1}
+                            max={100}
+                            onChange={(e) => setName(e.currentTarget.value)}
+                        />
+                    </FormControl>
+                    <FormControl>
+                        <FormLabel>Website</FormLabel>
+                        <Input
+                            type={"url"}
+                            placeholder="www.example.com"
+                            value={website}
+                            min={1}
+                            max={150}
+                            onChange={(e) => setWebsite(e.currentTarget.value)}
+                        />
+                    </FormControl>
+                    <FormControl>
+                        <FormLabel>Logo</FormLabel>
+                        {/* Change this with bucket upload */}
+                        <Input type={"file"} onChange={() => setLogo("")} />
+                    </FormControl>
+                    <FormControl>
+                        <FormLabel>Phone Number</FormLabel>
+                        <Input
+                            type={"tel"}
+                            value={phoneNumber}
+                            min={1}
+                            max={150}
+                            onChange={(e) => setPhoneNumber(e.currentTarget.value)}
+                        />
+                    </FormControl>
+                </ModalBody>
+                <ModalFooter>
+                    <HStack
+                        width={{ base: "100%", md: "50%" }}
+                        justifyContent={"space-between"}
+                    >
+                        <Button
+                            colorScheme="gray"
+                            width={"100%"}
+                            justifyContent={"space-between"}
+                            variant={"outline"}
+                            onClick={onClose}
+                        >
+                            Cancel <Icon as={AiOutlineClose} />
+                        </Button>
+                        <Button
+                            colorScheme="purple"
+                            justifyContent={"space-between"}
+                            width={"100%"}
+                            onClick={handleEdit}
+                        >
+                            Edit <Icon as={AiOutlineCheckCircle} />
+                        </Button>
+                    </HStack>
+                </ModalFooter>
+            </ModalContent>
+        </Modal>
+    );
+};
+
+export default EditOrgModal;

--- a/client/src/components/EditModal/EditTeam.tsx
+++ b/client/src/components/EditModal/EditTeam.tsx
@@ -1,0 +1,130 @@
+import {
+    Button,
+    FormControl,
+    FormLabel,
+    HStack,
+    Icon,
+    Input,
+    Modal,
+    ModalBody,
+    ModalCloseButton,
+    ModalContent,
+    ModalFooter,
+    ModalHeader,
+    ModalOverlay,
+    useToast,
+} from "@chakra-ui/react";
+import { AiOutlineClose, AiOutlineCheckCircle } from "react-icons/ai";
+import { useMutation, useQueryClient } from "react-query";
+import { EditTeamComponent } from "./types";
+import { useEffect, useState } from "react";
+import { iTeam } from "../../interfaces/teams.interface";
+import { editTeam } from "../../api/teams.api";
+
+const EditTeam: EditTeamComponent = ({ team, isOpen, onClose }) => {
+    const [name, setName] = useState<string>(team?.name || "");
+
+    const orgId = team?.organization_id || -1;
+
+    useEffect(() => {
+        setName(team?.name || "");
+    }, [team, isOpen]);
+
+    const toast = useToast();
+    const queryClient = useQueryClient();
+
+    const handleEdit = () => {
+        const data: Pick<iTeam, "name"> = {
+            name: name,
+        };
+        mutation.mutate(data);
+        cleanUp();
+    };
+
+    const mutation = useMutation({
+        mutationFn: (
+            data: Pick<iTeam, "name">
+        ) => {
+            return editTeam(orgId, team?.id, data);
+        },
+        onSuccess: () => {
+            toast({
+                status: "success",
+                title: "Edited team successfully.",
+            });
+            queryClient.invalidateQueries({ queryKey: "getTeam" });
+            queryClient.invalidateQueries({ queryKey: "getTeams" });
+            queryClient.invalidateQueries({ queryKey: "getEvents" });
+            queryClient.invalidateQueries({ queryKey: "getOrganizations" });
+            mutation.reset();
+        },
+        onError: (err: Error) => {
+            toast({
+                status: "error",
+                title: "Error editing team, please try again.",
+                description: err.message,
+            });
+        }
+    });
+
+    function cleanUp(): void {
+        setName("");
+        onClose();
+    }
+
+    return (
+        <Modal
+            isOpen={isOpen}
+            onClose={onClose}
+            isCentered
+            size={{ base: "full", md: "lg" }}
+            variant={"outline"}
+        >
+            <ModalOverlay />
+            <ModalContent>
+                <ModalCloseButton />
+                <ModalHeader>Edit Team - {team?.name}</ModalHeader>
+                <ModalBody>
+                    <FormControl isRequired>
+                        <FormLabel>Team Name</FormLabel>
+                        <Input
+                            type={"text"}
+                            value={name}
+                            min={1}
+                            max={100}
+                            placeholder={"Team Name"}
+                            pattern={"[A-Za-z0-9]{1,100}"}
+                            onChange={(e) => setName(e.target.value)}
+                        />
+                    </FormControl>
+                </ModalBody>
+                <ModalFooter>
+                    <HStack
+                        width={{ base: "100%", md: "50%" }}
+                        justifyContent={"space-between"}
+                    >
+                        <Button
+                            colorScheme="gray"
+                            width={"100%"}
+                            justifyContent={"space-between"}
+                            variant={"outline"}
+                            onClick={onClose}
+                        >
+                            Cancel <Icon as={AiOutlineClose} />
+                        </Button>
+                        <Button
+                            colorScheme="purple"
+                            justifyContent={"space-between"}
+                            width={"100%"}
+                            onClick={handleEdit}
+                        >
+                            Edit <Icon as={AiOutlineCheckCircle} />
+                        </Button>
+                    </HStack>
+                </ModalFooter>
+            </ModalContent>
+        </Modal>
+    );
+};
+
+export default EditTeam;

--- a/client/src/components/EditModal/types.ts
+++ b/client/src/components/EditModal/types.ts
@@ -1,6 +1,7 @@
 import { FunctionComponent } from "react";
 import { iEventJoinOrg } from "../../interfaces/events.interface";
 import { iOrganization } from "../../interfaces/organization.interface";
+import { iTeam } from "../../interfaces/teams.interface";
 
 interface EditOrgProps {
   org: iOrganization;
@@ -9,10 +10,8 @@ interface EditOrgProps {
 }
 
 interface EditTeamProps {
+  team: iTeam;
   isOpen: boolean;
-  orgId: number;
-  teamId: number;
-  orgName: string;
   onClose: () => void;
 }
 

--- a/client/src/components/EditModal/types.ts
+++ b/client/src/components/EditModal/types.ts
@@ -1,9 +1,10 @@
 import { FunctionComponent } from "react";
 import { iEventJoinOrg } from "../../interfaces/events.interface";
+import { iOrganization } from "../../interfaces/organization.interface";
 
 interface EditOrgProps {
+  org: iOrganization;
   isOpen: boolean;
-  orgId: number;
   onClose: () => void;
 }
 

--- a/client/src/views/Events/EventList.tsx
+++ b/client/src/views/Events/EventList.tsx
@@ -24,10 +24,17 @@ const EventList: EventsListComponent = () => {
 
   const { events, selectedOrg, selectedTeam } = useAppSelector((state) => state.organizations);
 
-  // Get the selected team's name to display in the header
-  const selectedTeamName = teamsData?.teams.find(
+  // Get the selected team's name to display in the header, and to pass to the AddEvent modal
+  const selectedTeamName = useAppSelector((state) => state.organizations.teams.find(
+    (team) => team.id === state.organizations.selectedTeam
+  )?.name) || teamsData?.teams.find(
     (team: iTeam) => team.id === selectedTeam
-  )?.name;
+  )?.name || "";
+
+  // Likewise for the Organization name
+  const selectedOrgName = useAppSelector((state) => state.organizations.organizations.find(
+    (org) => org.id === state.organizations.selectedOrg
+  )?.name) || orgData?.name || "";
 
   const { isOpen, onOpen, onClose } = useDisclosure();
   
@@ -64,8 +71,8 @@ const EventList: EventsListComponent = () => {
         </>
       )}
       {/* TODO: Don't show the Add Event option for unauthorized users */}
-      <AddEvent orgId={selectedOrg} orgName={orgData?.name || ""}
-        teamId={selectedTeam} teamName={selectedTeamName || ""}
+      <AddEvent orgId={selectedOrg} orgName={selectedOrgName}
+        teamId={selectedTeam} teamName={selectedTeamName}
         isOpen={isOpen} onClose={onClose} />
     </>
   );

--- a/client/src/views/Events/EventList.tsx
+++ b/client/src/views/Events/EventList.tsx
@@ -15,7 +15,6 @@ import { useDisclosure } from "@chakra-ui/hooks";
 import AddEvent from "../../components/AddModal/AddEvent";
 import OrganizationContext from "../Organizations/OrganizationContext";
 import { useContext } from "react";
-
 import { iTeam } from "../../interfaces/teams.interface";
 
 const EventList: EventsListComponent = () => {

--- a/client/src/views/Events/index.tsx
+++ b/client/src/views/Events/index.tsx
@@ -43,7 +43,7 @@ const EventsView = () => {
   const { isOpen, onOpen, onClose } = useDisclosure();
 
   useQuery({
-    queryKey: ["getOrgs"],
+    queryKey: ["getOrganizations"],
     queryFn: getOrganizations,
     onSuccess: (data) => dispatch(setOrgs(data.organizations)),
   });

--- a/client/src/views/Organizations/OrganizationHeader.tsx
+++ b/client/src/views/Organizations/OrganizationHeader.tsx
@@ -11,9 +11,12 @@ import {
   TitleCardFooter,
   TitleCardHeader,
 } from "../../components/Cards";
+import EditOrgModal from "../../components/EditModal/EditOrg";
 
 const OrganizationHeader: OrganizationHeaderComponent = ({ children }) => {
-  const { isOpen, onOpen, onClose } = useDisclosure();
+  const { isOpen: isQRCodeOpen, onOpen: onQRCodeOpen, onClose: onQRCodeClose } = useDisclosure();
+  const { isOpen: isEditOrgOpen, onOpen: onEditOrgOpen, onClose: onEditOrgClose } = useDisclosure();
+
   const { orgData, orgLoading } = useContext<iOrgContext>(OrganizationContext);
 
   return (
@@ -32,6 +35,7 @@ const OrganizationHeader: OrganizationHeaderComponent = ({ children }) => {
           rounded={"md"}
           gap={3}
           colorScheme="blue"
+          onClick={onEditOrgOpen}
         >
           Manage
           <Icon as={SettingsIcon} />
@@ -42,15 +46,17 @@ const OrganizationHeader: OrganizationHeaderComponent = ({ children }) => {
           rounded={"md"}
           gap={3}
           colorScheme="green"
-          onClick={onOpen}
+          onClick={onQRCodeOpen}
         >
           View QR Code
           <Icon as={HiQrCode} />
         </Button>
       </TitleCardFooter>
-      <TileModal isOpen={isOpen} onClose={onClose}>
+      <TileModal isOpen={isQRCodeOpen} onClose={onQRCodeClose}>
         {orgData !== undefined && <OrganizationTile organization={orgData} />}
       </TileModal>
+      <EditOrgModal org={orgData!}
+        isOpen={isEditOrgOpen} onClose={onEditOrgClose} />
     </TitleCardContainer>
   );
 };

--- a/client/src/views/Organizations/OrganizationPage.tsx
+++ b/client/src/views/Organizations/OrganizationPage.tsx
@@ -66,8 +66,6 @@ const OrganizationPage = () => {
     dispatch(setOrg(+organizationId));
     // Add organization teams to redux store
     dispatch(setTeams(teamsData?.teams || []));
-    // Set the active organization in the redux store
-    dispatch(setOrg(+organizationId!));
     // When a user is on this screen, adding events will be put into the global team
     // so set the active team to the organization-wide team
     dispatch(

--- a/client/src/views/Organizations/OrganizationPage.tsx
+++ b/client/src/views/Organizations/OrganizationPage.tsx
@@ -39,7 +39,7 @@ export const FAKE_MEMBERS = [
 const OrganizationPage = () => {
   const { organizationId } = useParams();
 
-  // const dispatch = useAppDispatch();
+  const dispatch = useAppDispatch();
 
   const { data: orgData, isLoading: orgLoading } = useQuery(
     "getOrganization",
@@ -55,10 +55,10 @@ const OrganizationPage = () => {
     "getEvents",
     () => getEventsInAnOrg(+organizationId!)
   );
-
+  
   // Determine the currently active team, if one hasn't been chosen, use the organization-wide team
-  // const { selectedTeam } = useAppSelector((state) => state.organizations);
-  /*
+  const { selectedTeam } = useAppSelector((state) => state.organizations);
+
   // When the teams data is loaded, set the active team to the organization-wide team
   useEffect(() => {
     // Add organization teams to redux store
@@ -67,21 +67,28 @@ const OrganizationPage = () => {
     dispatch(setOrg(+organizationId!));
     // By default, set the active team to the organization-wide team
     if (selectedTeam === 0 && teamsData && teamsData.teams.length > 0) {
-      console.log("Teams in this org: " + JSON.stringify(teamsData.teams));
-      // Searching for the name here because I'm not sure if the first element in the array is always the org-wide team
-      // TODO: This doesn't seem to be the most ideal way - what if the org-wide team name changes or something?
-      // Ideally, the org-wide team would have a flag or something that we could use to identify it, but it should
-      // also be the first element in the array (with the lowest ID)
       dispatch(
         setTeam(
-          teamsData.teams.find((team) =>
+          // The "global" team is initially named "Organization-wide Team"
+          teamsData?.teams?.find((team) =>
             team.name.includes("Organization-wide Team")
-          ).id
-        ) || teamsData.teams[0].id
+          )?.id
+          ||
+          // If the name's been changed, we can search for the lowest ID, since it'll have been
+          // created first. Ideally, the org-wide team would have a flag that we could use to identify it,
+          (teamsData?.teams?.reduce((acc, team) => {
+            if (team.id < acc.id) {
+              return team;
+            }
+            return acc;
+          }))?.id
+          || -1
+          // || teamsData?.teams[0]?.id || -1
+        )
       );
     }
   }, [orgData, teamsData]); // eslint-disable-line react-hooks/exhaustive-deps
-  */
+  
   return (
     <>
       <OrganizationContext.Provider

--- a/client/src/views/Organizations/OrganizationPage.tsx
+++ b/client/src/views/Organizations/OrganizationPage.tsx
@@ -56,37 +56,32 @@ const OrganizationPage = () => {
     () => getEventsInAnOrg(+organizationId!)
   );
   
-  // Determine the currently active team, if one hasn't been chosen, use the organization-wide team
-  const { selectedTeam } = useAppSelector((state) => state.organizations);
-
   // When the teams data is loaded, set the active team to the organization-wide team
   useEffect(() => {
     // Add organization teams to redux store
     dispatch(setTeams(teamsData?.teams || []));
     // Set the active organization in the redux store
     dispatch(setOrg(+organizationId!));
-    // By default, set the active team to the organization-wide team
-    if (selectedTeam === 0 && teamsData && teamsData.teams.length > 0) {
-      dispatch(
-        setTeam(
-          // The "global" team is initially named "Organization-wide Team"
-          teamsData?.teams?.find((team) =>
-            team.name.includes("Organization-wide Team")
-          )?.id
-          ||
-          // If the name's been changed, we can search for the lowest ID, since it'll have been
-          // created first. Ideally, the org-wide team would have a flag that we could use to identify it,
-          (teamsData?.teams?.reduce((acc, team) => {
-            if (team.id < acc.id) {
-              return team;
-            }
-            return acc;
-          }))?.id
-          || -1
-          // || teamsData?.teams[0]?.id || -1
-        )
-      );
-    }
+    // When a user is on this screen, adding events will be put into the global team
+    // so set the active team to the organization-wide team
+    dispatch(
+      setTeam(
+        // The "global" team is initially named "Organization-wide Team"
+        teamsData?.teams?.find((team) =>
+          team.name.includes("Organization-wide Team")
+        )?.id
+        ||
+        // If the name's been changed, we can search for the lowest ID, since it'll have been
+        // created first. Ideally, the org-wide team would have a flag that we could use to identify it,
+        (teamsData?.teams?.reduce((acc, team) => {
+          if (team.id < acc.id) {
+            return team;
+          }
+          return acc;
+        }))?.id
+        || -1
+      )
+    );
   }, [orgData, teamsData]); // eslint-disable-line react-hooks/exhaustive-deps
   
   return (

--- a/client/src/views/Organizations/OrganizationTeams.tsx
+++ b/client/src/views/Organizations/OrganizationTeams.tsx
@@ -8,19 +8,27 @@ import {
   Button,
   Icon,
   useColorModeValue,
+  useDisclosure
 } from "@chakra-ui/react";
-import { ChevronRightIcon } from "@chakra-ui/icons";
+import { ChevronRightIcon, PlusSquareIcon } from "@chakra-ui/icons";
 import { useContext } from "react";
 import { Link as RouterLink } from "react-router-dom";
 import OrganizationContext from "./OrganizationContext";
+import AddTeam from "../../components/AddModal/AddTeam";
 
 const OrganizationTeams = () => {
-  const { teamsData, teamsLoading } = useContext(OrganizationContext);
+  const { orgData, teamsData, teamsLoading } = useContext(OrganizationContext);
+  const { isOpen, onOpen, onClose } = useDisclosure();
+
   const cardBg = useColorModeValue("white", "#505050");
   return (
     <Stack alignSelf={"start"} width={"100%"}>
-      <Heading size={"sm"}>Teams: </Heading>
-      {/* TODO: 'Add Team' button here? */}
+      <HStack width={"100%"} justifyContent={"flex-start"}>
+        <Heading size={"sm"}>Teams: </Heading>
+        <Button colorScheme={"gray"} size={"sm"} onClick={onOpen}>
+          <Icon as={PlusSquareIcon} />
+        </Button>
+      </HStack>
       {teamsLoading && (
         <Skeleton
           width={"100%"}
@@ -56,6 +64,9 @@ const OrganizationTeams = () => {
             </CardBody>
           </Card>
         ))}
+      <AddTeam isOpen={isOpen} onClose={onClose}
+        orgId={orgData?.id || -1} orgName={orgData?.name || ""}
+      />
     </Stack>
   );
 };

--- a/client/src/views/Organizations/index.tsx
+++ b/client/src/views/Organizations/index.tsx
@@ -4,8 +4,12 @@ import { getOrganizations } from "../../api/organizations.api";
 import ErrorMessage from "../../components/Error";
 import { LoadingComponent } from "../../components/Loading";
 import Organizations from "./Organizations";
+import { useAppDispatch } from "../../app/hooks";
+import { setOrgs } from "../../features/Organizations/organizationSlice";
 
 const OrganizationView: FunctionComponent = () => {
+  const dispatch = useAppDispatch();
+  
   const {
     data: orgData,
     isLoading: orgIsLoading,
@@ -20,7 +24,7 @@ const OrganizationView: FunctionComponent = () => {
     error: (
       <ErrorMessage
         code={404}
-        message="Cant find organizations. Make sure you start the server!"
+        message="There's been an error locating your organizations. Please try again."
         flex={1}
       />
     ),
@@ -30,7 +34,10 @@ const OrganizationView: FunctionComponent = () => {
 
   if (orgIsLoading) return renderState.loading;
   else if (orgIsError) return renderState.error;
-  else if (orgData?.organizations) return renderState.success;
+  else if (orgData?.organizations) {
+    dispatch(setOrgs(orgData.organizations));
+    return renderState.success;
+  } 
 };
 
 export default OrganizationView;

--- a/client/src/views/Teams/TeamHeader.tsx
+++ b/client/src/views/Teams/TeamHeader.tsx
@@ -1,5 +1,5 @@
 import { useContext } from "react";
-import { Text, Button, Icon } from "@chakra-ui/react";
+import { Text, Button, Icon, useDisclosure } from "@chakra-ui/react";
 import { SettingsIcon } from "@chakra-ui/icons";
 import {
   TitleCardContainer,
@@ -8,9 +8,12 @@ import {
 } from "../../components/Cards";
 import { TeamContext } from "./TeamContext";
 import { TeamHeaderComponent } from "./types";
+import EditTeam from "../../components/EditModal/EditTeam";
 
 export const TeamHeader: TeamHeaderComponent = ({ children }) => {
   const { teamData, teamLoading } = useContext(TeamContext);
+
+  const { isOpen, onOpen, onClose } = useDisclosure();
 
   return (
     <TitleCardContainer>
@@ -23,11 +26,13 @@ export const TeamHeader: TeamHeaderComponent = ({ children }) => {
           rounded={"md"}
           gap={3}
           colorScheme="blue"
+          onClick={onOpen}
         >
           Manage
           <Icon as={SettingsIcon} />
         </Button>
       </TitleCardFooter>
+      <EditTeam team={teamData} isOpen={isOpen} onClose={onClose} />
     </TitleCardContainer>
   );
 };

--- a/client/src/views/Teams/TeamPage.tsx
+++ b/client/src/views/Teams/TeamPage.tsx
@@ -10,6 +10,9 @@ import { useAppDispatch } from "../../app/hooks";
 import { setEvents } from "../../features/Organizations/organizationSlice";
 import { FAKE_MEMBERS } from "../Organizations/OrganizationPage";
 import TeamMembers from "./TeamMembers";
+import { setTeam } from "../../features/Organizations/organizationSlice";
+import { useEffect } from "react";
+import { useAppSelector } from "../../app/hooks";
 
 const TeamPage = () => {
   const { organizationId, teamId } = useParams();
@@ -18,6 +21,11 @@ const TeamPage = () => {
   const { data, isLoading } = useQuery("getTeam", () =>
     getTeam(+organizationId!, +teamId!)
   );
+  
+  // When the team data is loaded, set the team in the redux store
+  useEffect(() => {
+    dispatch(setTeam(+teamId!));
+  }, [teamId, data]);
 
   const { data: eventData } = useQuery(
     "getEventsByTeam",

--- a/client/src/views/Teams/TeamPage.tsx
+++ b/client/src/views/Teams/TeamPage.tsx
@@ -33,7 +33,7 @@ const TeamPage = () => {
     }
     dispatch(setTeam(+teamId!));
     dispatch(setOrg(+organizationId!));
-  }, [teamId, data]);
+  }, [teamId, data]); // eslint-disable-line react-hooks/exhaustive-deps
 
   const { data: eventData } = useQuery(
     "getEventsByTeam",

--- a/client/src/views/Teams/TeamPage.tsx
+++ b/client/src/views/Teams/TeamPage.tsx
@@ -7,12 +7,10 @@ import { TeamHeader } from "./TeamHeader";
 import EventList from "../Events/EventList";
 import { getEventsInATeam } from "../../api/events.api";
 import { useAppDispatch } from "../../app/hooks";
-import { setEvents } from "../../features/Organizations/organizationSlice";
+import { setEvents, setOrg, setTeam } from "../../features/Organizations/organizationSlice";
 import { FAKE_MEMBERS } from "../Organizations/OrganizationPage";
 import TeamMembers from "./TeamMembers";
-import { setTeam } from "../../features/Organizations/organizationSlice";
 import { useEffect } from "react";
-import { useAppSelector } from "../../app/hooks";
 
 const TeamPage = () => {
   const { organizationId, teamId } = useParams();
@@ -22,9 +20,10 @@ const TeamPage = () => {
     getTeam(+organizationId!, +teamId!)
   );
   
-  // When the team data is loaded, set the team in the redux store
+  // When the team data is loaded, set the team (and parent org) in the redux store
   useEffect(() => {
     dispatch(setTeam(+teamId!));
+    dispatch(setOrg(+organizationId!));
   }, [teamId, data]);
 
   const { data: eventData } = useQuery(
@@ -34,8 +33,6 @@ const TeamPage = () => {
       onSuccess: (data) => dispatch(setEvents(data.events)),
     }
   );
-
-  console.log(eventData?.events);
 
   return (
     <TeamContext.Provider


### PR DESCRIPTION
* Users can edit Teams and Organization details via the Manage buttons on their respective pages.
* Fixed organization data not being set in Redux store upon viewing "All Organizations" page.
* Fixed Add Event modal not receiving proper target Org/Team info in certain places
* Fixed auto-selection of the organization's default team upon browsing to the Organization page.
* Minor formatting and comments fixes.